### PR TITLE
Add support for notificaitons through ntfy.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,28 @@
 # Changelog
 
-## v1.1.0
+## v1.1.1 - 2022-10-04
+
+- Added support for sending a notification through [ntfy.sh](https://ntfy.sh) on success
+
+## v1.1.0 - 2022-10-04
 
 - Added support for the updated BayIMCO API
 - Added filter to find vaccination appointments against a specific variant, such as BA.1 or BA.4/5
 - Added support for the `--debug` option to additionally print debug output
 
-## v1.0.3
+## v1.0.3 - 2021-11-30
 
 - Increased the frequency of authentication token refreshes
 - Added pre-commit hooks config
 
-## v1.0.2
+## v1.0.2 - 2021-11-30
 
 - Added support for the `--latest-day` option
 
-## v1.0.1
+## v1.0.1 - 2021-11-30
 
 - Fixed a bug where the `--earliest-day` option wasn't optional, but should have been
 
-## v1.0.0
+## v1.0.0 - 2021-11-30
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ options:
   --first-vaccine-id FIRST_VACCINE_ID
                         The ID of the vaccine that was used for the first jab. Only required for the second vaccination.
   --variant VARIANT     Variants to find vaccines for; either ba1 or ba45. Leave blank for any.
+  --ntfy-topic NTFY_TOPIC
+                        ntfy.sh topic to send a message to on success. See https://ntfy.sh for details.
+
 ```
 
 #### Vaccine IDs
@@ -86,6 +89,11 @@ first jab. In addition to `--dose=second`, add `--first-vaccine-id` according to
 | Comirnaty Original/Omicron BA.1 (BioNTech/Pfizer)   | 009 |
 | Spikevax 0 (Zero)/O (Omicron) (Moderna)             | 010 |
 | Comirnaty Original/Omicron BA.4-5 (BioNTech/Pfizer) | 011 |
+
+#### Notifications
+
+The checker can send a notification to an [ntfy.sh](https://ntfy.sh) topic. Use the `--ntfy-topic` option to specify the
+topic name and subscribe to the notifications on your phone or on the web app.
 
 #### Checking until successful
 

--- a/impf.py
+++ b/impf.py
@@ -103,6 +103,13 @@ def main():
         required=False,
         help="Variants to find vaccines for; either ba1 or ba45. Leave blank for any.",
     )
+    parser.add_argument(
+        "--ntfy-topic",
+        type=str,
+        default=None,
+        required=False,
+        help="ntfy.sh topic to send a message to on success. See https://ntfy.sh for details.",
+    )
     args = parser.parse_args()
 
     if args.dose == VaccinationType.SECOND and args.first_vaccine is None:
@@ -117,7 +124,10 @@ def main():
     )
 
     checker = ImpfChecker(
-        username=args.email, password=args.password, citizen_id=args.citizen_id
+        username=args.email,
+        password=args.password,
+        citizen_id=args.citizen_id,
+        ntfy_topic=args.ntfy_topic,
     )
 
     if args.interval is not None:


### PR DESCRIPTION
When the checker finds an appointment and, if requested, books it, it can send a notification to a ntfy.sh topic. This adds a CLI option to specify a topic name.